### PR TITLE
fix #12 : 잡힌 말이 보드에서 제거되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/yutgame/model/Piece.java
+++ b/src/main/java/com/yutgame/model/Piece.java
@@ -50,13 +50,18 @@ public class Piece {
         if (currentNode != null) {
             currentNode.removePiece(this);
         }
-        // 새 노드에 추가
-        nextNode.addPiece(this);
-        // 현재 노드 갱신
+
+        // 새 노드에 추가 (nextNode가 null일 경우 처리 생략)
+        if (nextNode != null) {
+            nextNode.addPiece(this);
+        }
+
+        // 현재 노드 갱신 (null일 수도 있음)
         this.currentNode = nextNode;
 
         // 그룹 이동 로직(다른 말과 함께 이동 등)은 필요시 구현
     }
+
 
     /**
      * 아군 말과 업기(그룹화) 처리

--- a/src/main/java/com/yutgame/model/YutGame.java
+++ b/src/main/java/com/yutgame/model/YutGame.java
@@ -180,9 +180,13 @@ public class YutGame {
         if (toCapture.isEmpty()) {
             return false;
         }
-        BoardNode start = board.getStartNode();
+
         for (Piece captured : toCapture) {
-            captured.moveTo(start);
+            // 잡힌 말은 보드에서 제거
+            captured.getCurrentNode().removePiece(captured);
+            captured.ungroup();                        // 그룹 해제 (업기 상태 제거)
+            // 출발 전 상태로 되돌림
+            captured.moveTo(null);                     // moveTo(null)은 아래처럼 만들어야 함
         }
         return true;
     }


### PR DESCRIPTION
- 기존에는 말이 잡혔을 때 시작 노드로 돌아가 보드에 표시되는 오류가 있었음
- 말이 잡혔을 때, 보드에서 사라지게 하고 미출발 상태로 수정함