### PR TITLE
[Fix/30] dfsPaths 갈림길 처리 수정. 나오면 안되는 노드 예외처리 (CENTER_NODE 지나갈 때)

### DIFF
--- a/src/main/java/com/yutgame/model/SquareBoard.java
+++ b/src/main/java/com/yutgame/model/SquareBoard.java
@@ -156,12 +156,53 @@ public class SquareBoard implements YutBoard {
             path.removeLast();
             return;
         }
+
+        // CENTER_NODE 특별 처리
+        if ("CENTER_NODE".equals(node.getId()) && !path.isEmpty()) {
+            // 이전 노드가 무엇인지 확인 (path의 마지막 바로 이전 노드)
+            BoardNode prevNode = path.size() > 1 ? path.get(path.size() - 2) : null;
+
+            if (prevNode != null) {
+                String prevId = prevNode.getId();
+                BoardNode nextNode = null;
+
+                // NE2에서 온 경우 SW1로 진행
+                if ("NE2".equals(prevId)) {
+                    nextNode = findNodeById(node.getNextNodes(), "SW1");
+                }
+                // NW2에서 온 경우 SE1로 진행
+                else if ("NW2".equals(prevId)) {
+                    nextNode = findNodeById(node.getNextNodes(), "SE1");
+                }
+
+                // 특별 경로가 결정된 경우
+                if (nextNode != null) {
+                    dfsPaths(nextNode, steps-1, path, results);
+                    path.removeLast();
+                    return; // 다른 경로는 탐색하지 않음
+                }
+            }
+        }
+
+
         // 갈림길 (nextNodes) 탐색
         for (BoardNode nxt : node.getNextNodes()) {
             dfsPaths(nxt, steps-1, path, results);
         }
         path.removeLast();
     }
+    /**
+     * ID로 노드 찾기 헬퍼 메서드
+     */
+    private BoardNode findNodeById(List<BoardNode> nodes, String id) {
+        for (BoardNode node : nodes) {
+            if (id.equals(node.getId())) {
+                return node;
+            }
+        }
+        return null;
+    }
+
 
     @Override
     public List<BoardNode> getPossiblePreviousNodes(BoardNode target) {

--- a/src/main/java/com/yutgame/model/SquareBoard.java
+++ b/src/main/java/com/yutgame/model/SquareBoard.java
@@ -153,14 +153,14 @@ public class SquareBoard implements YutBoard {
             if (!results.contains(node)) {
                 results.add(node);
             }
-            path.remove(path.size()-1);
+            path.removeLast();
             return;
         }
         // 갈림길 (nextNodes) 탐색
         for (BoardNode nxt : node.getNextNodes()) {
             dfsPaths(nxt, steps-1, path, results);
         }
-        path.remove(path.size()-1);
+        path.removeLast();
     }
 
     @Override


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3ebe3f24-43a4-4d4f-b81b-72ab0e784a9f)

- 함수에서 CENTER_NODE를 지나갈 땐 이전 노드 접근에 따라 방향을 맞춰 다음 노드 하나만 추가하는 형태로 수정했습니다.
- 위 사진에서 CORNER_NE의 말에서 모가 나온 상황인다 SE2 안뜸 굿
